### PR TITLE
Added config option to return separate fallback image for frontpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ For titles there is no way it can be empty, at least the last fallback will alwa
 
 | Version | XP version |
 | ------------- | ------------- |
+| 1.4.0 | 6.7.0 |
 | 1.3.3 | 6.7.0 |
 | 1.3.2 | 6.7.0 |
 | 1.3.1 | 6.7.0 |
@@ -118,6 +119,12 @@ For titles there is no way it can be empty, at least the last fallback will alwa
 | 0.5.0 | 6.3.0 |
 
 ## Changelog
+
+### Version 1.4.0
+
+* Added config option to return separate fallback image for frontpage.
+* Added config option to return raw (unscaled) fallback images for both frontpage and normal content.
+* Added config option to return fallback images as https.
 
 ### Version 1.3.3
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ For titles there is no way it can be empty, at least the last fallback will alwa
 
 * Added config option to return separate fallback image for frontpage.
 * Added config option to return raw (unscaled) fallback images for both frontpage and normal content.
-* Added config option to return fallback images as https.
 
 ### Version 1.3.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # Project settings
 #
 group = com.enonic.app
-version = 1.3.3
+version = 1.4.0
 projectName = metafields
 appName = com.enonic.app.metafields
 xpVersion = 6.7.0

--- a/src/main/resources/lib/site.js
+++ b/src/main/resources/lib/site.js
@@ -105,29 +105,42 @@ exports.getMetaDescription = function(content, site) {
 	return metaDescription;
 };
 
-exports.getOpenGraphImage = function(content, defaultImg) {
+exports.getOpenGraphImage = function(content, defaultImg, defaultImgPrescaled) {
 	var siteConfig = getConfig();
 
 	var userDefinedPaths = siteConfig.pathsImages || '';
 	var userDefinedArray = userDefinedPaths ? commaStringToArray(userDefinedPaths) : [];
 	var userDefinedValue = userDefinedPaths ? findValueInJson(content,userDefinedArray) : null;
 
-	// Set basic image options
-	var imageOpts = {
-		scale: 'block(1200,630)', // Open Graph requires 600x315 for landscape format. Double that for retina display.
-		quality: 85,
-		format: 'jpg',
-		type: 'absolute'
-	};
+	var ogImage;
 
-	// Try to find an image in the content's image or images properties
-	var imageArray = libs.util.data.forceArray( userDefinedValue || content.data.image || content.data.images || []);
+    // Try to find an image in the content's image or images properties
+    var imageArray = libs.util.data.forceArray( userDefinedValue || content.data.image || content.data.images || []);
 
-	// Set the ID to either the first image in the set or the default image ID
-	imageOpts.id = imageArray.length ? imageArray[0] : defaultImg;
+    if (imageArray.length || (defaultImg && !defaultImgPrescaled)) {
+        // Set basic image options
+        var imageOpts = {
+            scale: 'block(1200,630)', // Open Graph requires 600x315 for landscape format. Double that for retina display.
+            quality: 85,
+            format: 'jpg',
+            type: 'absolute'
+        };
+
+        // Set the ID to either the first image in the set or use the default image ID
+        imageOpts.id = imageArray.length ? imageArray[0] : defaultImg;
+
+        ogImage = imageOpts.id ? libs.portal.imageUrl(imageOpts) : null;
+	} else if (defaultImg && defaultImgPrescaled) {
+        // Serve pre-optimized image directly
+        ogImage = libs.portal.attachmentUrl({
+            id:defaultImg,
+            type:'absolute'
+        });
+    }
 
 	// Return the image URL or nothing
-	return imageOpts.id ? libs.portal.imageUrl(imageOpts) : null;
+	return ogImage;
 };
+
 
 

--- a/src/main/resources/site/filters/add-metadata.js
+++ b/src/main/resources/site/filters/add-metadata.js
@@ -46,15 +46,6 @@ exports.responseFilter = function(req, res) {
         fallbackImageIsPrescaled = siteConfig.frontpageImageIsPrescaled;
     }
     var image = libs.site.getOpenGraphImage(content, fallbackImage, fallbackImageIsPrescaled);
-    // Fix hard coded URL schema returned by portal functions
-    if (siteConfig.useHttps) {
-        if (url) {
-            url = url.replace('http://', 'https://');
-        }
-        if (image) {
-            image = image.replace('http://', 'https://');
-        }
-    }
 
     var params = {
         title: pageTitle,

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -38,11 +38,6 @@
 		<field-set name="defaults">
 			<label>Fallback settings</label>
 			<items>
-				<input name="useHttps" type="CheckBox">
-					<label>Use https for absolute fallback image paths?</label>
-					<help-text>Absolute URLs are normally returned as http. Check this to force them to https!</help-text>
-					<occurrences minimum="0" maximum="1"/>
-				</input>
 				<input name="seoImage" type="ImageSelector">
 					<label>Content image fallback</label>
 					<help-text>If current content image is not found, use this as last resort. Tip: add company logo here!</help-text>

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -38,9 +38,29 @@
 		<field-set name="defaults">
 			<label>Fallback settings</label>
 			<items>
+				<input name="useHttps" type="CheckBox">
+					<label>Use https for absolute fallback image paths?</label>
+					<help-text>Absolute URLs are normally returned as http. Check this to force them to https!</help-text>
+					<occurrences minimum="0" maximum="1"/>
+				</input>
 				<input name="seoImage" type="ImageSelector">
 					<label>Content image fallback</label>
 					<help-text>If current content image is not found, use this as last resort. Tip: add company logo here!</help-text>
+					<occurrences minimum="0" maximum="1"/>
+				</input>
+				<input name="seoImageIsPrescaled" type="CheckBox">
+					<label>Serve the content fallback image as is. No system scaling.</label>
+					<help-text>Image will otherwise be scaled to 1200x630px and set to jpg with quality 85</help-text>
+					<occurrences minimum="0" maximum="1"/>
+				</input>
+				<input name="frontpageImage" type="ImageSelector">
+					<label>Frontpage image fallback</label>
+					<help-text>Use this for a special image for the frontpage only!</help-text>
+					<occurrences minimum="0" maximum="1"/>
+				</input>
+				<input name="frontpageImageIsPrescaled" type="CheckBox">
+					<label>Serve the frontpage image as is. No system scaling.</label>
+					<help-text>Image will otherwise be scaled to 1200x630px and set to jpg with quality 85</help-text>
 					<occurrences minimum="0" maximum="1"/>
 				</input>
 				<input name="seoTitle" type="TextLine">


### PR DESCRIPTION
We had a few needs for improving the SEO presence and sharing data for our site. So we modified app-metafields a bit. All changes should be backward compatible, but there are a few new config options:
* Added config option to return separate fallback image for frontpage.
* Added config option to return raw (unscaled) fallback images for both frontpage and normal content.
* Added config option to return fallback images as https.