### PR TITLE
Feature: Added setting and overwrite config from app.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ We only evaluate for matches in the JSON `data`-node for each content. So if you
 
 You can put a file on the server to configure all running instances of the app across one server. This is a feature that you can turn on and off per site through the app setting interface when adding the app. This means you can have the cake and eat it too!
 
-Locate your `$XP_HOME/config/` folder and create a file called `app-metafields.cfg` and fill it with data like this, changing variables as needed (comment out the ones you don't need).
+Locate your `$XP_HOME/config/` folder and create a file called `app-metafields.cfg` and fill it with data like this, changing variables as needed (comment out the ones you don't need):
+
+```
+canonical=true
+```
 
 ## Waterfall logic for meta fields
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This app will add the following functionality to your site:
 7. Canonical meta tag
 8. Robots.txt exclude setting
 9. **New in 1.6**: Widget for Content Studio that displays all the SEO data!
+10. **New in 1.7**: Configure the app through config-files on the server.
 
 ## Installation
 
@@ -69,6 +70,12 @@ Add field names as comma separated strings, like `field1, field2, long-fieldname
 
 We only evaluate for matches in the JSON `data`-node for each content. So if you fill in `myField`, we'll look for `data.myField` in the content JSON (refer to Enonic XP's documentation on `getContent()` function).
 
+### Advanced: configuration files
+
+You can put a file on the server to configure all running instances of the app across one server. This is a feature that you can turn on and off per site through the app setting interface when adding the app. This means you can have the cake and eat it too!
+
+Locate your `$XP_HOME/config/` folder and create a file called `app-metafields.cfg` and fill it with data like this, changing variables as needed (comment out the ones you don't need).
+
 ## Waterfall logic for meta fields
 
 We will always add the meta fields for title and description, and most of the meta fields for Open Graph. However, if we cannot find any image to use, we won't add the meta fields for Open Graph image or Twitter Cards image.
@@ -107,6 +114,7 @@ For titles there is no way it can be empty, at least the last fallback will alwa
 
 | Version | XP version |
 | ------------- | ------------- |
+| 1.7.0 | 6.15.0 |
 | 1.6.0 | 6.15.0 |
 | 1.5.0 | 6.15.0 |
 | 1.4.0 | 6.7.0 |
@@ -124,6 +132,10 @@ For titles there is no way it can be empty, at least the last fallback will alwa
 | 0.5.0 | 6.3.0 |
 
 ## Changelog
+
+### Version 1.7.0
+
+* New: configure the app from configuration files on the server. Credit @edwardgronroos of TINE AS.
 
 ### Version 1.6.0
 

--- a/src/main/resources/lib/local.js
+++ b/src/main/resources/lib/local.js
@@ -21,8 +21,6 @@ function getConfig(site) {
 			config[prop] = value;
 		}
 	}
-
-	log.info(JSON.stringify(config, null, 2));
 	return config;
 }
 exports.getLang = function(content, site) {

--- a/src/main/resources/lib/local.js
+++ b/src/main/resources/lib/local.js
@@ -108,10 +108,9 @@ function stringOrNull(o) {
 }
 
 // Concat site title? Trigger if set to true in settings, or if not set at all (default = true)
-exports.getAppendix = function(site, siteConfig, isFrontpage) {
+exports.getAppendix = function(site, isFrontpage) {
+	var siteConfig = getConfig(site);
 	var titleAppendix = '';
-	log.info(siteConfig.titleBehaviour);
-	log.info(!siteConfig.hasOwnProperty("titleBehaviour"));
 	if (siteConfig.titleBehaviour || !siteConfig.hasOwnProperty("titleBehaviour") ) {
 		 var separator = siteConfig.titleSeparator || '-';
 		 var titleRemoveOnFrontpage = siteConfig.hasOwnProperty("titleFrontpageBehaviour") ? siteConfig.titleFrontpageBehaviour : true; // Default true needs to be respected

--- a/src/main/resources/lib/local.js
+++ b/src/main/resources/lib/local.js
@@ -12,6 +12,11 @@ function getConfig(site) {
 	if (!config) {
 		config = exports.getSiteConfig(site, app.name);
 	}
+	if(app.config && !config.disableAppConfig) {
+		for (var prop in app.config) {
+			config[prop] = app.config[prop];
+		}
+	}
 	return config;
 }
 exports.getLang = function(content, site) {

--- a/src/main/resources/lib/local.js
+++ b/src/main/resources/lib/local.js
@@ -14,9 +14,15 @@ function getConfig(site) {
 	}
 	if(app.config && !config.disableAppConfig) {
 		for (var prop in app.config) {
-			config[prop] = app.config[prop];
+			var value = app.config[prop];
+			if (value === 'true' || value === 'false') {
+				value = value === 'true';
+			}
+			config[prop] = value;
 		}
 	}
+
+	log.info(JSON.stringify(config, null, 2));
 	return config;
 }
 exports.getLang = function(content, site) {
@@ -106,6 +112,8 @@ function stringOrNull(o) {
 // Concat site title? Trigger if set to true in settings, or if not set at all (default = true)
 exports.getAppendix = function(site, siteConfig, isFrontpage) {
 	var titleAppendix = '';
+	log.info(siteConfig.titleBehaviour);
+	log.info(!siteConfig.hasOwnProperty("titleBehaviour"));
 	if (siteConfig.titleBehaviour || !siteConfig.hasOwnProperty("titleBehaviour") ) {
 		 var separator = siteConfig.titleSeparator || '-';
 		 var titleRemoveOnFrontpage = siteConfig.hasOwnProperty("titleFrontpageBehaviour") ? siteConfig.titleFrontpageBehaviour : true; // Default true needs to be respected

--- a/src/main/resources/site/filters/add-metadata.js
+++ b/src/main/resources/site/filters/add-metadata.js
@@ -14,7 +14,7 @@ exports.responseFilter = function(req, res) {
 
     var isFrontpage = site._path === content._path;
     var pageTitle = libs.local.getPageTitle(content, site);
-    var titleAppendix = libs.local.getAppendix(site, siteConfig, isFrontpage);
+    var titleAppendix = libs.local.getAppendix(site, isFrontpage);
 
     var siteVerification = siteConfig.siteVerification || null;
 

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -20,6 +20,12 @@
 					<help-text>Caution: Use this to ask search engines to ignore your entire site!</help-text>
 					<occurrences minimum="0" maximum="1"/>
 				</input>
+				<input name="disableAppConfig" type="CheckBox">
+					<label>Don't overwrite values from app.config</label>
+					<help-text></help-text>
+					<default>false</default>
+					<occurrences minimum="0" maximum="1"/>
+				</input>
 			</items>
 		</field-set>
 		<field-set name="twitter">

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -22,7 +22,7 @@
 				</input>
 				<input name="disableAppConfig" type="CheckBox">
 					<label>Don't overwrite values from app.config</label>
-					<help-text></help-text>
+					<help-text>It's possible to configure this app for all your site through a file on the server, here you can disable this behavior.</help-text>
 					<default>false</default>
 					<occurrences minimum="0" maximum="1"/>
 				</input>


### PR DESCRIPTION
tine.no have around 50 sites in XP, to allow brands and editors to customize templates for their need and use. But that also mean we have to maintain config for the SEO app in 50 copies 🙈