### PR TITLE
Adds the possibility to add a full JSON path to the advanced field-set

### DIFF
--- a/src/main/resources/lib/common.js
+++ b/src/main/resources/lib/common.js
@@ -78,14 +78,14 @@ function commaStringToArray(str) {
 	return arr;
 }
 
-function findValueInJson(json, paths) {
+function findValueInJson(json, paths, fullPath) {
 	var value = null;
 	var pathLength = paths.length;
-	var jsonPath = ";";
+	var jsonPath;
 
 	for (var i = 0; i < pathLength; i++) {
 		if (paths[i]) {
-			jsonPath = 'json.data["' + paths[i].split('.').join('"]["') + '"]'; // Wrap property so we can have dashes in it
+			jsonPath = (fullPath) ? 'json["' + paths[i].split('.').join('"]["') + '"]' : 'json.data["' + paths[i].split('.').join('"]["') + '"]'; // Wrap property so we can have dashes in it
 			try {
 				value = eval(jsonPath);
 			} catch (e) {
@@ -146,7 +146,7 @@ exports.getPageTitle = function (content, site) {
 
 	var userDefinedPaths = siteConfig.pathsTitles || '';
 	var userDefinedArray = userDefinedPaths ? commaStringToArray(userDefinedPaths) : [];
-	var userDefinedValue = userDefinedPaths ? findValueInJson(content, userDefinedArray) : null;
+	var userDefinedValue = userDefinedPaths ? findValueInJson(content, userDefinedArray, siteConfig.fullPath) : null;
 
 	var setWithMixin = content.x[appNamePath]
 		&& content.x[appNamePath][mixinPath]
@@ -168,7 +168,7 @@ exports.getMetaDescription = function (content, site) {
 
 	var userDefinedPaths = siteConfig.pathsDescriptions || '';
 	var userDefinedArray = userDefinedPaths ? commaStringToArray(userDefinedPaths) : [];
-	var userDefinedValue = userDefinedPaths ? findValueInJson(content, userDefinedArray) : null;
+	var userDefinedValue = userDefinedPaths ? findValueInJson(content, userDefinedArray, siteConfig.fullPath) : null;
 
 	var setWithMixin = content.x[appNamePath]
 		&& content.x[appNamePath][mixinPath]
@@ -192,7 +192,7 @@ exports.getImage = function (content, site, defaultImg, defaultImgPrescaled) {
 	const siteConfig = exports.getTheConfig(site);
 	const userDefinedPaths = siteConfig.pathsImages || '';
 	const userDefinedArray = userDefinedPaths ? commaStringToArray(userDefinedPaths) : [];
-	const userDefinedValue = userDefinedPaths ? findValueInJson(content, userDefinedArray) : null;
+	const userDefinedValue = userDefinedPaths ? findValueInJson(content, userDefinedArray, siteConfig.fullPath) : null;
 	const setWithMixin = content.x[appNamePath]
 		&& content.x[appNamePath][mixinPath]
 		&& content.x[appNamePath][mixinPath].seoImage;

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -128,7 +128,7 @@
 			<label>Advanced: prioritized JSON paths</label><!-- Customized paths yes/no --><!-- +Text about advanced/custom settings needed -->
 			<items>
 				<input name="fullPath" type="checkbox">
-					<label>Access the field by the full json path?</label>
+					<label>Access the field by the full JSON path?</label>
 					<help-text>By default the app will look for the regular fields in your content type (data.myField in the content JSON). If checked you can choose the field setting the entire content JSON structure.</help-text>
 				</input>
 				<input name="pathsImages" type="TextLine">

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -127,6 +127,10 @@
 		<field-set>
 			<label>Advanced: prioritized JSON paths</label><!-- Customized paths yes/no --><!-- +Text about advanced/custom settings needed -->
 			<items>
+				<input name="fullPath" type="checkbox">
+					<label>Access the field by the full json path?</label>
+					<help-text>By default the app will look for the regular fields in your content type (data.myField in the content JSON). If checked you can choose the field setting the entire content JSON structure.</help-text>
+				</input>
 				<input name="pathsImages" type="TextLine">
 					<label>Images (comma-separated)</label>
 					<help-text>Any custom fields in your content types that you want to use for generating metadata for images? Add them here, comma separated. It's the json paths we're after here, like "headerImage, someOtherfField" or "someOtherField". It will be prioritized before all other fields. Check Github readme for detailed explanation.</help-text>


### PR DESCRIPTION
I created an option to allow the `pathsImages, pathsTitles and pathsDescriptions` parameters to have a field defined from a path other than the data section (json.data).
This will help the editor to have a wide choice of fields, allowing him to choose a field from the x-data, for example.