### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ projectName = metafields
 appName = com.enonic.app.metafields
 xpVersion = 8.0.0-B4
 
-version=2.0.2-SNAPSHOT
+version=3.0.0-SNAPSHOT


### PR DESCRIPTION
Branches the XP 7 maintenance line and bumps master to the next major SNAPSHOT for XP 8.

## Changes
- `gradle.properties`: `version=2.0.2-SNAPSHOT` → `version=3.0.0-SNAPSHOT`
- `.github/workflows/enonic-gradle.yml`: add `releaseBranch:` listing `master` and `2.x` so both branches are recognized as release branches by the build-and-publish action.

## Maintenance branch
The new `2.x` branch was created at [`5c5b753`](https://github.com/enonic/app-metafields/commit/5c5b753a70e1a4fa08d2524b8c2799d34bfcad6f) — the post-`v2.0.1` "Updated to next SNAPSHOT version" commit on master. Its `gradle.properties` shows `version=2.0.2-SNAPSHOT`, so the release tooling will not attempt to re-release `v2.0.1`.

A companion PR against `2.x` adds the same `releaseBranch:` config there so pushes to `2.x` are classified correctly (the action reads the workflow file from the branch under build).

Reference: app-booster `master` vs `1.x`.