### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `2.x`. This is required so pushes to `2.x` are classified as release-branch builds — the build-and-publish action reads `releaseBranch:` from the workflow file on the branch under build, so the maintenance branch needs its own copy.

No version bump, no other changes — those are master-only (per app-booster `1.x`).

Companion to the master PR: #389.