### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 	include xplibs.context
 	include xplibs.node
 	include xplibs.portal
-	include "com.enonic.lib:lib-thymeleaf:3.0.0-SNAPSHOT"
+	include libs.lib.thymeleaf
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,5 @@
+[versions]
+thymeleaf = "3.0.0-SNAPSHOT"
+
+[libraries]
+lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }


### PR DESCRIPTION
## Summary

Adds `gradle/libs.versions.toml` and migrates the single inline-pinned dependency (`com.enonic.lib:lib-thymeleaf:3.0.0-SNAPSHOT`) into it. `build.gradle` now references the artifact via `libs.lib.thymeleaf`.

Pin-for-pin migration — no version bumps. `xpVersion` stays in `gradle.properties` as before; `xplibs.*` accessors are untouched.

## Conventions

Following the dominant pattern in neighbouring catalogs (`app-features`, `app-facebook-pixel`, etc.):

- Version keys are short, lowercase, hyphen-separated.
- Library keys mirror the artifact name (`lib-thymeleaf`).
- `version.ref` is used instead of an inline `version =` even for the singleton.
- `[versions]` and `[libraries]` sorted alphabetically (trivially, with one entry each).

## Catalog

```toml
[versions]
thymeleaf = "3.0.0-SNAPSHOT"

[libraries]
lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
```

## Verification

`./gradlew build --refresh-dependencies` — green; 28 tests pass. `./gradlew dependencies --configuration runtimeClasspath` resolves `com.enonic.lib:lib-thymeleaf:3.0.0-SNAPSHOT` identically to pre-migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)